### PR TITLE
Removed dep on alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "deque"
 description = "A (mostly) lock-free concurrent work-stealing deque"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Samuel Fredrickson <kinghajj@gmail.com>", "Linus Färnstrand <faern@faern.net>"]
 readme = "README.md"
 # see also LICENSE-APACHE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,7 +402,6 @@ impl<T: Send> Drop for Buffer<T> {
         // It is assumed that all buffers are empty on drop.
         let size = buffer_alloc_size::<T>(self.log_size);
         unsafe {
-            //deallocate(self.storage as *mut u8, size, min_align_of::<T>());
             let buffer = slice::from_raw_parts(self.storage, size);
             drop(buffer);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ use std::boxed::Box;
 use std::vec::Vec;
 use std::mem::{forget, size_of, transmute};
 use std::ptr;
-use std::slice;
 
 use std::sync::atomic::{AtomicIsize, AtomicPtr};
 use std::sync::atomic::Ordering::SeqCst;
@@ -400,6 +399,6 @@ impl<T: Send> Drop for Buffer<T> {
     fn drop(&mut self) {
         // It is assumed that all buffers are empty on drop.
         let size = buffer_alloc_size::<T>(self.log_size);
-        unsafe { drop(slice::from_raw_parts(self.storage, size)); }
+        unsafe { drop(Vec::from_raw_parts(self.storage as *mut T, 0, size)); }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,8 +349,7 @@ impl<T: Send> Buffer<T> {
     unsafe fn new(log_size: usize) -> Buffer<T> {
         let size = buffer_alloc_size::<T>(log_size);
 
-        let mut buffer_vec = Vec::with_capacity(size);
-        buffer_vec.set_len(size);
+        let buffer_vec = Vec::with_capacity(size);
         let buffer: *const T = buffer_vec.get_unchecked(0);
         forget(buffer_vec);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,9 +400,6 @@ impl<T: Send> Drop for Buffer<T> {
     fn drop(&mut self) {
         // It is assumed that all buffers are empty on drop.
         let size = buffer_alloc_size::<T>(self.log_size);
-        unsafe {
-            let buffer = slice::from_raw_parts(self.storage, size);
-            drop(buffer);
-        }
+        unsafe { drop(slice::from_raw_parts(self.storage, size)); }
     }
 }


### PR DESCRIPTION
I wanted to remove the dependency to alloc since it's not allowed in beta.
I replaced it with allocating a vector and taking an unsafe pointer into it. On drop I recreate a slice from that pointer and let it drop in the normal Rust way.

WARNING: I'm far from 100% sure this works the way I intend it to. I'm not totally sure what I have done here, but the tests seem to work. I have run both the tests in deque and in my projects depending on deque without problems.