### PR TITLE
debug_assert that type T of BufferPool<T> is not zero_sized

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,8 @@ impl<T: Send> BufferPool<T> {
     /// Allocates a new buffer pool which in turn can be used to allocate new
     /// deques.
     pub fn new() -> BufferPool<T> {
+        // don't allow zero-sized type, which causes allocation to fail
+        debug_assert!(size_of::<T>() > 0);
         BufferPool { pool: Arc::new(Mutex::new(Vec::new())) }
     }
 


### PR DESCRIPTION
Otherwise 'An unknown error occurred' which needs a debugger
to trace it back to a EXC_BAD_ACCESS during allocation

Fixes https://github.com/kinghajj/deque/issues/4