### PR TITLE
Use vec hack to allow deque to be used on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: rust
-rust: nightly
+rust:
+- stable
+- beta
+- nightly
 sudo: false
 env:
   global:


### PR DESCRIPTION
This isn't pretty, but it will allow deque to be used on the stable branches until the alloc api is stabilized.