### PR TITLE
Use relaxed atomics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "deque"
 description = "A (mostly) lock-free concurrent work-stealing deque"
-version = "0.2.3"
-authors = ["Alex Crichton <alex@alexcrichton.com>", "Samuel Fredrickson <kinghajj@gmail.com>", "Linus Färnstrand <faern@faern.net>"]
+version = "0.3.0"
+authors = ["Alex Crichton <alex@alexcrichton.com>", "Samuel Fredrickson <kinghajj@gmail.com>", "Linus Färnstrand <faern@faern.net>", "Amanieu d'Antras <amanieu@gmail.com>"]
 readme = "README.md"
 # see also LICENSE-APACHE
 license-file = "LICENSE-MIT"

--- a/README.md
+++ b/README.md
@@ -4,34 +4,30 @@
 
 This module contains an implementation of the Chase-Lev work stealing deque
 described in "Dynamic Circular Work-Stealing Deque". The implementation is
-heavily based on the pseudocode found in the paper.
+heavily based on the implementation using C11 atomics in "Correct and
+Efficient Work Stealing for Weak Memory Models".
 
-This implementation does not want to have the restriction of a garbage
-collector for reclamation of buffers, and instead it uses a shared pool of
-buffers. This shared pool is required for correctness in this
-implementation.
-
-The only lock-synchronized portions of this deque are the buffer allocation
-and deallocation portions. Otherwise all operations are lock-free.
+The only potentially lock-synchronized portion of this deque is the
+occasional call to the memory allocator when growing the deque. Otherwise
+all operations are lock-free.
 
 ## Example
 
-    use deque::BufferPool;
+    use deque;
 
-    let mut pool = BufferPool::new();
-    let (mut worker, mut stealer) = pool.deque();
+    let (worker, stealer) = deque::new();
 
     // Only the worker may push/pop
-    worker.push(1i);
+    worker.push(1);
     worker.pop();
 
     // Stealers take data from the other end of the deque
-    worker.push(1i);
+    worker.push(1);
     stealer.steal();
 
     // Stealers can be cloned to have many stealers stealing in parallel
-    worker.push(1i);
-    let mut stealer2 = stealer.clone();
+    worker.push(1);
+    let stealer2 = stealer.clone();
     stealer2.steal();
 
 ## History

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,22 +11,18 @@
 //!
 //! This module contains an implementation of the Chase-Lev work stealing deque
 //! described in "Dynamic Circular Work-Stealing Deque". The implementation is
-//! heavily based on the pseudocode found in the paper.
+//! heavily based on the implementation using C11 atomics in "Correct and
+//! Efficient Work Stealing for Weak Memory Models".
 //!
-//! This implementation does not want to have the restriction of a garbage
-//! collector for reclamation of buffers, and instead it uses a shared pool of
-//! buffers. This shared pool is required for correctness in this
-//! implementation.
-//!
-//! The only lock-synchronized portions of this deque are the buffer allocation
-//! and deallocation portions. Otherwise all operations are lock-free.
+//! The only potentially lock-synchronized portion of this deque is the
+//! occasional call to the memory allocator when growing the deque. Otherwise
+//! all operations are lock-free.
 //!
 //! # Example
 //!
-//!     use deque::BufferPool;
+//!     use deque;
 //!
-//!     let mut pool = BufferPool::new();
-//!     let (mut worker, mut stealer) = pool.deque();
+//!     let (worker, stealer) = deque::new();
 //!
 //!     // Only the worker may push/pop
 //!     worker.push(1);
@@ -38,43 +34,27 @@
 //!
 //!     // Stealers can be cloned to have many stealers stealing in parallel
 //!     worker.push(1);
-//!     let mut stealer2 = stealer.clone();
+//!     let stealer2 = stealer.clone();
 //!     stealer2.steal();
-
-
-// NB: the "buffer pool" strategy is not done for speed, but rather for
-//     correctness. For more info, see the comment on `swap_buffer`
-
-// FIXME: all atomic operations in this module use a SeqCst ordering. That is
-//      probably overkill
 
 pub use self::Stolen::*;
 
-use std::sync::{Arc, Mutex};
-use std::boxed::Box;
-use std::vec::Vec;
-use std::mem::{forget, size_of, transmute};
+use std::sync::Arc;
+use std::mem::forget;
 use std::ptr;
+use std::marker::PhantomData;
+use std::cell::Cell;
 
-use std::sync::atomic::{AtomicIsize, AtomicPtr};
-use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::{AtomicIsize, AtomicPtr, fence};
+use std::sync::atomic::Ordering::{SeqCst, Acquire, Release, Relaxed};
 
-// Once the queue is less than 1/K full, then it will be downsized. Note that
-// the deque requires that this number be less than 2.
-static K: isize = 4;
-
-// Minimum number of bits that a buffer size should be. No buffer will resize to
-// under this value, and all deques will initially contain a buffer of this
-// size.
-//
-// The size in question is 1 << MIN_BITS
-static MIN_BITS: usize = 7;
+// Initial size for a buffer.
+static MIN_SIZE: usize = 32;
 
 struct Deque<T: Send> {
     bottom: AtomicIsize,
     top: AtomicIsize,
     array: AtomicPtr<Buffer<T>>,
-    pool: BufferPool<T>,
 }
 
 /// Worker half of the work-stealing deque. This worker has exclusive access to
@@ -83,18 +63,20 @@ struct Deque<T: Send> {
 /// There may only be one worker per deque.
 pub struct Worker<T: Send> {
     deque: Arc<Deque<T>>,
-}
 
-unsafe impl<T: Send> Send for Worker<T> { }
+    // Marker so that the Worker is Send but not Sync. The worker can only be
+    // accessed from a single thread at once. Ideally we would use a negative
+    // impl here but these are not stable yet.
+    marker: PhantomData<Cell<()>>,
+}
 
 /// The stealing half of the work-stealing deque. Stealers have access to the
 /// opposite end of the deque from the worker, and they only have access to the
 /// `steal` method.
+#[derive(Clone)]
 pub struct Stealer<T: Send> {
     deque: Arc<Deque<T>>,
 }
-
-unsafe impl<T: Send> Send for Stealer<T> { }
 
 /// When stealing some data, this is an enumeration of the possible outcomes.
 #[derive(PartialEq, Debug)]
@@ -106,17 +88,6 @@ pub enum Stolen<T> {
     Abort,
     /// The stealer has successfully stolen some data.
     Data(T),
-}
-
-/// The allocation pool for buffers used by work-stealing deques. Right now this
-/// structure is used for reclamation of memory after it is no longer in use by
-/// deques.
-///
-/// This data structure is protected by a mutex, but it is rarely used. Deques
-/// will only use this structure when allocating a new buffer or deallocating a
-/// previous one.
-pub struct BufferPool<T: Send> {
-    pool: Arc<Mutex<Vec<Box<Buffer<T>>>>>,
 }
 
 /// An internal buffer used by the chase-lev deque. This structure is actually
@@ -134,51 +105,22 @@ pub struct BufferPool<T: Send> {
 ///
 ///   2. We can certainly avoid bounds checks using *T instead of Vec<T>, although
 ///      LLVM is probably pretty good at doing this already.
+///
+/// Note that we keep old buffers around after growing because stealers may still
+/// be concurrently accessing them. The buffers are kept in a linked list, with
+/// each buffer pointing to the previous, smaller buffer. This doesn't leak any
+/// memory because all buffers in the list are freed when the deque is dropped.
 struct Buffer<T: Send> {
-    storage: *const T,
-    log_size: usize,
+    storage: *mut T,
+    size: usize,
+    prev: Option<Box<Buffer<T>>>,
 }
 
-unsafe impl<T: Send> Send for Buffer<T> { }
-
-impl<T: Send> BufferPool<T> {
-    /// Allocates a new buffer pool which in turn can be used to allocate new
-    /// deques.
-    pub fn new() -> BufferPool<T> {
-        // don't allow zero-sized type, which causes allocation to fail
-        debug_assert!(size_of::<T>() > 0);
-        BufferPool { pool: Arc::new(Mutex::new(Vec::new())) }
-    }
-
-    /// Allocates a new work-stealing deque which will send/receiving memory to
-    /// and from this buffer pool.
-    pub fn deque(&self) -> (Worker<T>, Stealer<T>) {
-        let a = Arc::new(Deque::new(self.clone()));
-        let b = a.clone();
-        (Worker { deque: a }, Stealer { deque: b })
-    }
-
-    fn alloc(&mut self, bits: usize) -> Box<Buffer<T>> {
-        unsafe {
-            let mut pool = self.pool.lock().unwrap();
-            match pool.iter().position(|x| x.size() >= (1 << bits)) {
-                Some(i) => pool.remove(i),
-                None => Box::new(Buffer::new(bits))
-            }
-        }
-    }
-
-    fn free(&self, buf: Box<Buffer<T>>) {
-        let mut pool = self.pool.lock().unwrap();
-        match pool.iter().position(|v| v.size() > buf.size()) {
-            Some(i) => pool.insert(i, buf),
-            None => pool.push(buf),
-        }
-    }
-}
-
-impl<T: Send> Clone for BufferPool<T> {
-    fn clone(&self) -> BufferPool<T> { BufferPool { pool: self.pool.clone() } }
+/// Allocates a new work-stealing deque.
+pub fn new<T: Send>() -> (Worker<T>, Stealer<T>) {
+    let a = Arc::new(Deque::new());
+    let b = a.clone();
+    (Worker { deque: a, marker: PhantomData }, Stealer { deque: b })
 }
 
 impl<T: Send> Worker<T> {
@@ -191,13 +133,6 @@ impl<T: Send> Worker<T> {
     pub fn pop(&self) -> Option<T> {
         unsafe { self.deque.pop() }
     }
-
-    /// Gets access to the buffer pool that this worker is attached to. This can
-    /// be used to create more deques which share the same buffer pool as this
-    /// deque.
-    pub fn pool<'a>(&'a self) -> &'a BufferPool<T> {
-        &self.deque.pool
-    }
 }
 
 impl<T: Send> Stealer<T> {
@@ -205,140 +140,116 @@ impl<T: Send> Stealer<T> {
     pub fn steal(&self) -> Stolen<T> {
         unsafe { self.deque.steal() }
     }
-
-    /// Gets access to the buffer pool that this stealer is attached to. This
-    /// can be used to create more deques which share the same buffer pool as
-    /// this deque.
-    pub fn pool<'a>(&'a self) -> &'a BufferPool<T> {
-        &self.deque.pool
-    }
 }
-
-impl<T: Send> Clone for Stealer<T> {
-    fn clone(&self) -> Stealer<T> {
-        Stealer { deque: self.deque.clone() }
-    }
-}
-
-// Almost all of this code can be found directly in the paper so I'm not
-// personally going to heavily comment what's going on here.
 
 impl<T: Send> Deque<T> {
-    fn new(mut pool: BufferPool<T>) -> Deque<T> {
-        let buf = pool.alloc(MIN_BITS);
+    fn new() -> Deque<T> {
+        let buf = Box::new(unsafe { Buffer::new(MIN_SIZE) });
         Deque {
             bottom: AtomicIsize::new(0),
             top: AtomicIsize::new(0),
-            array: AtomicPtr::new(unsafe { transmute(buf) }),
-            pool: pool,
+            array: AtomicPtr::new(Box::into_raw(buf)),
         }
     }
 
     unsafe fn push(&self, data: T) {
-        let mut b = self.bottom.load(SeqCst);
-        let t = self.top.load(SeqCst);
-        let mut a = self.array.load(SeqCst);
-        let size = b - t;
-        if size >= (*a).size() - 1 {
-            // You won't find this code in the chase-lev deque paper. This is
-            // alluded to in a small footnote, however. We always free a buffer
-            // when growing in order to prevent leaks.
-            a = self.swap_buffer(b, a, (*a).resize(b, t, 1));
-            b = self.bottom.load(SeqCst);
+        let b = self.bottom.load(Relaxed);
+        let t = self.top.load(Acquire);
+        let mut a = self.array.load(Relaxed);
+
+        // Grow the buffer if it is full.
+        let size = b.wrapping_sub(t);
+        if size == (*a).size() {
+            a = Box::into_raw(Box::from_raw(a).grow(b, t));
+            self.array.store(a, Release);
         }
+
         (*a).put(b, data);
-        self.bottom.store(b + 1, SeqCst);
+        fence(Release);
+        self.bottom.store(b.wrapping_add(1), Relaxed);
     }
 
     unsafe fn pop(&self) -> Option<T> {
-        let b = self.bottom.load(SeqCst);
-        let a = self.array.load(SeqCst);
-        let b = b - 1;
-        self.bottom.store(b, SeqCst);
-        let t = self.top.load(SeqCst);
-        let size = b - t;
-        if size < 0 {
-            self.bottom.store(t, SeqCst);
+        let b = self.bottom.load(Relaxed);
+
+        // Early exit if the deque is empty. This avoids the need for a SeqCst
+        // fence in this case.
+        let t = self.top.load(Relaxed);
+        if b.wrapping_sub(t) <= 0 {
             return None;
         }
+
+        // Make sure bottom is stored before top is read.
+        let b = b.wrapping_sub(1);
+        self.bottom.store(b, Relaxed);
+        fence(SeqCst);
+        let t = self.top.load(Relaxed);
+
+        // If the deque is empty, restore bottom and exit.
+        let size = b.wrapping_sub(t);
+        if size < 0 {
+            self.bottom.store(b.wrapping_add(1), Relaxed);
+            return None;
+        }
+
+        // Fetch the element from the queue.
+        let a = self.array.load(Relaxed);
         let data = (*a).get(b);
-        if size > 0 {
-            self.maybe_shrink(b, t);
+
+        // If this was the last element in the queue, check for races.
+        if size != 0 {
             return Some(data);
         }
-        if self.top.compare_and_swap(t, t + 1, SeqCst) == t {
-            self.bottom.store(t + 1, SeqCst);
+        if self.top.compare_and_swap(t, t.wrapping_add(1), SeqCst) == t {
+            self.bottom.store(t.wrapping_add(1), Relaxed);
             return Some(data);
         } else {
-            self.bottom.store(t + 1, SeqCst);
-            forget(data); // someone else stole this value
+            self.bottom.store(t.wrapping_add(1), Relaxed);
+            forget(data); // Someone else stole this value
             return None;
         }
     }
 
     unsafe fn steal(&self) -> Stolen<T> {
-        let t = self.top.load(SeqCst);
-        let old = self.array.load(SeqCst);
-        let b = self.bottom.load(SeqCst);
-        let a = self.array.load(SeqCst);
-        let size = b - t;
-        if size <= 0 { return Empty }
-        if size % (*a).size() == 0 {
-            if a == old && t == self.top.load(SeqCst) {
-                return Empty
-            }
-            return Abort
+        // Make sure top is read before bottom.
+        let t = self.top.load(Acquire);
+        fence(SeqCst);
+        let b = self.bottom.load(Acquire);
+
+        // Exit if the queue is empty.
+        let size = b.wrapping_sub(t);
+        if size <= 0 {
+            return Empty;
         }
+
+        // Fetch the element from the queue.
+        let a = self.array.load(Acquire);
         let data = (*a).get(t);
-        if self.top.compare_and_swap(t, t + 1, SeqCst) == t {
+
+        // Attempt to increment top.
+        if self.top.compare_and_swap(t, t.wrapping_add(1), SeqCst) == t {
             Data(data)
         } else {
-            forget(data); // someone else stole this value
+            forget(data); // Someone else stole this value
             Abort
         }
     }
-
-    unsafe fn maybe_shrink(&self, b: isize, t: isize) {
-        let a = self.array.load(SeqCst);
-        if b - t < (*a).size() / K && b - t > (1 << MIN_BITS) {
-            self.swap_buffer(b, a, (*a).resize(b, t, -1));
-        }
-    }
-
-    // Helper routine not mentioned in the paper which is used in growing and
-    // shrinking buffers to swap in a new buffer into place. As a bit of a
-    // recap, the whole point that we need a buffer pool rather than just
-    // calling malloc/free directly is that stealers can continue using buffers
-    // after this method has called 'free' on it. The continued usage is simply
-    // a read followed by a forget, but we must make sure that the memory can
-    // continue to be read after we flag this buffer for reclamation.
-    unsafe fn swap_buffer(&self, b: isize, old: *mut Buffer<T>,
-                          buf: Buffer<T>) -> *mut Buffer<T> {
-        let newbuf: *mut Buffer<T> = transmute(Box::new(buf));
-        self.array.store(newbuf, SeqCst);
-        let ss = (*newbuf).size();
-        self.bottom.store(b + ss, SeqCst);
-        let t = self.top.load(SeqCst);
-        if self.top.compare_and_swap(t, t + ss, SeqCst) != t {
-            self.bottom.store(b, SeqCst);
-        }
-        self.pool.free(transmute(old));
-        return newbuf;
-    }
 }
-
 
 impl<T: Send> Drop for Deque<T> {
     fn drop(&mut self) {
-        let t = self.top.load(SeqCst);
-        let b = self.bottom.load(SeqCst);
-        let a = self.array.load(SeqCst);
-        // Free whatever is leftover in the dequeue, and then move the buffer
-        // back into the pool.
-        for i in t..b {
-            let _: T = unsafe { (*a).get(i) };
+        let t = self.top.load(Relaxed);
+        let b = self.bottom.load(Relaxed);
+        let a = self.array.load(Relaxed);
+
+        // Free whatever is leftover in the deque, and then free the buffer.
+        // This will also free all linked buffers.
+        let mut i = t;
+        while i != b {
+            unsafe { (*a).get(i) };
+            i = i.wrapping_add(1);
         }
-        self.pool.free(unsafe { transmute(a) });
+        unsafe { Box::from_raw(a) };
     }
 }
 
@@ -350,30 +261,30 @@ unsafe fn take_ptr_from_vec<T>(mut buf: Vec<T>) -> *mut T {
 }
 
 #[inline]
-unsafe fn allocate<T>(number: usize) -> *const T {
+unsafe fn allocate<T>(number: usize) -> *mut T {
     let v = Vec::with_capacity(number);
     take_ptr_from_vec(v)
 }
 
 #[inline]
-unsafe fn deallocate<T>(ptr: *const T, number: usize) {
-    Vec::from_raw_parts(ptr as *mut T, 0, number);
+unsafe fn deallocate<T>(ptr: *mut T, number: usize) {
+    Vec::from_raw_parts(ptr, 0, number);
 }
 
 impl<T: Send> Buffer<T> {
-    unsafe fn new(log_size: usize) -> Buffer<T> {
+    unsafe fn new(size: usize) -> Buffer<T> {
         Buffer {
-            storage: allocate(1 << log_size),
-            log_size: log_size,
+            storage: allocate(size),
+            size: size,
+            prev: None,
         }
     }
 
-    fn size(&self) -> isize { 1 << self.log_size }
+    fn size(&self) -> isize { self.size as isize }
 
-    // Apparently LLVM cannot optimize (foo % (1 << bar)) into this implicitly
-    fn mask(&self) -> isize { (1 << self.log_size) - 1 }
+    fn mask(&self) -> isize { self.size as isize - 1 }
 
-    unsafe fn elem(&self, i: isize) -> *const T {
+    unsafe fn elem(&self, i: isize) -> *mut T {
         self.storage.offset(i & self.mask())
     }
 
@@ -388,19 +299,19 @@ impl<T: Send> Buffer<T> {
     // Unsafe because this unsafely overwrites possibly uninitialized or
     // initialized data.
     unsafe fn put(&self, i: isize, t: T) {
-        ptr::write(self.elem(i) as *mut T, t);
+        ptr::write(self.elem(i), t);
     }
 
     // Again, unsafe because this has incredibly dubious ownership violations.
     // It is assumed that this buffer is immediately dropped.
-    unsafe fn resize(&self, b: isize, t: isize, delta: isize) -> Buffer<T> {
-        // NB: not entirely obvious, but thanks to 2's complement,
-        // casting delta to usize and then adding gives the desired
-        // effect.
-        let buf = Buffer::new(self.log_size.wrapping_add(delta as usize));
-        for i in t..b {
+    unsafe fn grow(self: Box<Buffer<T>>, b: isize, t: isize) -> Box<Buffer<T>> {
+        let mut buf = Box::new(Buffer::new(self.size * 2));
+        let mut i = t;
+        while i != b {
             buf.put(i, self.get(i));
+            i = i.wrapping_add(1);
         }
+        buf.prev = Some(self);
         return buf;
     }
 }
@@ -408,6 +319,6 @@ impl<T: Send> Buffer<T> {
 impl<T: Send> Drop for Buffer<T> {
     fn drop(&mut self) {
         // It is assumed that all buffers are empty on drop.
-        unsafe { deallocate(self.storage as *mut T, 1 << self.log_size) }
+        unsafe { deallocate(self.storage, self.size) }
     }
 }


### PR DESCRIPTION
This PR fixes #8 by using relaxed atomics based on this paper: http://www.di.ens.fr/~zappa/readings/ppopp13.pdf

The implementation is based on this one for C++11: https://github.com/Amanieu/asyncplusplus/blob/master/src/work_steal_queue.h

There are several major changes:
- A deque no longer uses a buffer pool, it instead keeps a linked list of all previous buffers when it grows. These buffers are freed when the deque is dropped. This is required because the implementation described in the paper requires that old buffers are not modified after a grow since a thief might still be accessing them. This is an API change, which requires a version bump.
- The code now properly handles integer overflows for the `top` and `bottom` indices by using wrapping operations.
- `Worker` is no longer `Sync`, since it can only be accessed by one thread at a time.
- Reduced the initial deque size from 128 elements to 32 elements. This should be enough in the majority of cases.
- A lot of code cleanups